### PR TITLE
Desabilitar generadores desnecessários

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,25 +2,18 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
+
 Bundler.require(*Rails.groups)
 
 module PhotoContest
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.generators do |g|
+      g.assets    =   false
+      g.helper    =   false
+      g.jbuilder  =   false
+    end
+
   end
 end


### PR DESCRIPTION
Os generators por default geram muitos arquivos desnecessários. 
Desabilitei a geração dos arquivos:

*  .coffee
* .scss
* .jbuilder

E também dos helpers.
Esses arquivos não serão mais gerados no comando `scaffold`.